### PR TITLE
[Subject]거래 조회 최적화 및 멱등성 지원 추가

### DIFF
--- a/transaction-module/src/main/java/com/wirebarley/transaction/dto/DepositRequest.java
+++ b/transaction-module/src/main/java/com/wirebarley/transaction/dto/DepositRequest.java
@@ -20,9 +20,12 @@ public class DepositRequest {
     @DecimalMin(value = "1", message = "입금 금액은 1원 이상이어야 합니다.")
     private BigDecimal amount;
 
+    private String idempotencyKey;
+
     @Builder
-    public DepositRequest(String accountNumber, BigDecimal amount) {
+    public DepositRequest(String accountNumber, BigDecimal amount, String idempotencyKey) {
         this.accountNumber = accountNumber;
         this.amount = amount;
+        this.idempotencyKey = idempotencyKey;
     }
 }

--- a/transaction-module/src/main/java/com/wirebarley/transaction/dto/TransactionResponse.java
+++ b/transaction-module/src/main/java/com/wirebarley/transaction/dto/TransactionResponse.java
@@ -1,6 +1,7 @@
 package com.wirebarley.transaction.dto;
 
 import com.wirebarley.transaction.entity.Transaction;
+import com.wirebarley.transaction.entity.TransactionStatus;
 import com.wirebarley.transaction.entity.TransactionType;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,7 @@ public class TransactionResponse {
     private String fromAccountNumber;
     private String toAccountNumber;
     private BigDecimal balanceAfter;
+    private TransactionStatus status;
     private LocalDateTime createdAt;
 
     public static TransactionResponse from(Transaction transaction) {
@@ -32,6 +34,7 @@ public class TransactionResponse {
                 .toAccountNumber(transaction.getToAccount() != null ?
                         transaction.getToAccount().getAccountNumber() : null)
                 .balanceAfter(transaction.getBalanceAfter())
+                .status(transaction.getStatus())
                 .createdAt(transaction.getCreatedAt())
                 .build();
     }

--- a/transaction-module/src/main/java/com/wirebarley/transaction/dto/TransferRequest.java
+++ b/transaction-module/src/main/java/com/wirebarley/transaction/dto/TransferRequest.java
@@ -23,10 +23,13 @@ public class TransferRequest {
     @DecimalMin(value = "1", message = "이체 금액은 1원 이상이어야 합니다.")
     private BigDecimal amount;
 
+    private String idempotencyKey;
+
     @Builder
-    public TransferRequest(String fromAccountNumber, String toAccountNumber, BigDecimal amount) {
+    public TransferRequest(String fromAccountNumber, String toAccountNumber, BigDecimal amount, String idempotencyKey) {
         this.fromAccountNumber = fromAccountNumber;
         this.toAccountNumber = toAccountNumber;
         this.amount = amount;
+        this.idempotencyKey = idempotencyKey;
     }
 }

--- a/transaction-module/src/main/java/com/wirebarley/transaction/dto/WithdrawRequest.java
+++ b/transaction-module/src/main/java/com/wirebarley/transaction/dto/WithdrawRequest.java
@@ -20,9 +20,12 @@ public class WithdrawRequest {
     @DecimalMin(value = "1", message = "출금 금액은 1원 이상이어야 합니다.")
     private BigDecimal amount;
 
+    private String idempotencyKey;
+
     @Builder
-    public WithdrawRequest(String accountNumber, BigDecimal amount) {
+    public WithdrawRequest(String accountNumber, BigDecimal amount, String idempotencyKey) {
         this.accountNumber = accountNumber;
         this.amount = amount;
+        this.idempotencyKey = idempotencyKey;
     }
 }

--- a/transaction-module/src/main/java/com/wirebarley/transaction/entity/TransactionStatus.java
+++ b/transaction-module/src/main/java/com/wirebarley/transaction/entity/TransactionStatus.java
@@ -1,0 +1,8 @@
+package com.wirebarley.transaction.entity;
+
+public enum TransactionStatus {
+    PENDING,    // 처리 중
+    SUCCESS,    // 성공
+    FAILED,     // 실패
+    CANCELLED   // 취소
+}

--- a/transaction-module/src/test/java/com/wirebarley/transaction/service/TransactionServiceTest.java
+++ b/transaction-module/src/test/java/com/wirebarley/transaction/service/TransactionServiceTest.java
@@ -130,7 +130,7 @@ class TransactionServiceTest {
 
             given(accountRepository.findByAccountNumberWithLock("1234567890"))
                     .willReturn(Optional.of(testAccount));
-            given(transactionRepository.sumDailyAmountByAccountAndType(
+            given(transactionRepository.sumDailyAmountByOwnerAccountAndType(
                     any(Account.class), eq(TransactionType.WITHDRAWAL), any(), any()))
                     .willReturn(BigDecimal.ZERO);
 
@@ -163,7 +163,7 @@ class TransactionServiceTest {
 
             given(accountRepository.findByAccountNumberWithLock("1234567890"))
                     .willReturn(Optional.of(testAccount));
-            given(transactionRepository.sumDailyAmountByAccountAndType(
+            given(transactionRepository.sumDailyAmountByOwnerAccountAndType(
                     any(Account.class), eq(TransactionType.WITHDRAWAL), any(), any()))
                     .willReturn(BigDecimal.ZERO);
 
@@ -185,7 +185,7 @@ class TransactionServiceTest {
             // 이미 600,000원 출금한 상태
             given(accountRepository.findByAccountNumberWithLock("1234567890"))
                     .willReturn(Optional.of(testAccount));
-            given(transactionRepository.sumDailyAmountByAccountAndType(
+            given(transactionRepository.sumDailyAmountByOwnerAccountAndType(
                     any(Account.class), eq(TransactionType.WITHDRAWAL), any(), any()))
                     .willReturn(new BigDecimal("600000"));
 
@@ -213,7 +213,7 @@ class TransactionServiceTest {
             // 이미 600,000원 출금한 상태 → 400,000 추가하면 딱 1,000,000원
             given(accountRepository.findByAccountNumberWithLock("1234567890"))
                     .willReturn(Optional.of(testAccount));
-            given(transactionRepository.sumDailyAmountByAccountAndType(
+            given(transactionRepository.sumDailyAmountByOwnerAccountAndType(
                     any(Account.class), eq(TransactionType.WITHDRAWAL), any(), any()))
                     .willReturn(new BigDecimal("600000"));
 
@@ -264,7 +264,7 @@ class TransactionServiceTest {
                     .willReturn(Optional.of(testAccount2));
             given(accountRepository.findByAccountNumberWithLock("1234567890"))
                     .willReturn(Optional.of(testAccount));
-            given(transactionRepository.sumDailyAmountByAccountAndType(
+            given(transactionRepository.sumDailyAmountByOwnerAccountAndType(
                     any(Account.class), eq(TransactionType.TRANSFER_OUT), any(), any()))
                     .willReturn(BigDecimal.ZERO);
 
@@ -328,7 +328,7 @@ class TransactionServiceTest {
                     .willReturn(Optional.of(testAccount2));
             given(accountRepository.findByAccountNumberWithLock("1234567890"))
                     .willReturn(Optional.of(testAccount));
-            given(transactionRepository.sumDailyAmountByAccountAndType(
+            given(transactionRepository.sumDailyAmountByOwnerAccountAndType(
                     any(Account.class), eq(TransactionType.TRANSFER_OUT), any(), any()))
                     .willReturn(BigDecimal.ZERO);
 
@@ -353,7 +353,7 @@ class TransactionServiceTest {
             given(accountRepository.findByAccountNumberWithLock("1234567890"))
                     .willReturn(Optional.of(testAccount));
             // 이미 2,500,000원 이체한 상태
-            given(transactionRepository.sumDailyAmountByAccountAndType(
+            given(transactionRepository.sumDailyAmountByOwnerAccountAndType(
                     any(Account.class), eq(TransactionType.TRANSFER_OUT), any(), any()))
                     .willReturn(new BigDecimal("2500000"));
 
@@ -384,7 +384,7 @@ class TransactionServiceTest {
             given(accountRepository.findByAccountNumberWithLock("1234567890"))
                     .willReturn(Optional.of(testAccount));
             // 이미 2,000,000원 이체한 상태 → 1,000,000 추가하면 딱 3,000,000원
-            given(transactionRepository.sumDailyAmountByAccountAndType(
+            given(transactionRepository.sumDailyAmountByOwnerAccountAndType(
                     any(Account.class), eq(TransactionType.TRANSFER_OUT), any(), any()))
                     .willReturn(new BigDecimal("2000000"));
 
@@ -427,7 +427,7 @@ class TransactionServiceTest {
                     .willReturn(Optional.of(testAccount2));
             given(accountRepository.findByAccountNumberWithLock("1234567890"))
                     .willReturn(Optional.of(testAccount));
-            given(transactionRepository.sumDailyAmountByAccountAndType(
+            given(transactionRepository.sumDailyAmountByOwnerAccountAndType(
                     any(Account.class), eq(TransactionType.TRANSFER_OUT), any(), any()))
                     .willReturn(BigDecimal.ZERO);
 


### PR DESCRIPTION
[Body]
- 작업 내용:
 - owner_account_id 추가로 거래내역 조회 쿼리 최적화 (OR 조건 → 단일 컬럼 인덱스)
  - TransactionStatus enum 추가 (PENDING, SUCCESS, FAILED, CANCELLED)
  - idempotencyKey 필드로 중복 거래 방지 기능 구현
  - 일일 한도 계산 시 SUCCESS 상태만 집계
  - README.md API 문서 업데이트 (멱등성, 거래상태 설명 추가)

[Issue]
 DB 설계 개선: 쿼리 최적화, 상태/멱등성